### PR TITLE
Add date_pairs to imagette titles in view.py

### DIFF
--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -1315,7 +1315,7 @@ def plot_subplot4figure(i, inps, ax, data, metadata):
             elif 20 < num_subplot <= 50:
                 subplot_title = title_str.replace('_','\n').replace('-','\n')
             else:
-                subplot_title = f'{title_ind}'
+                subplot_title = f'{title_ind}\n{title_str}'
 
         # plot title
         if subplot_title:


### PR DESCRIPTION
**Description of proposed changes**

The image-ettes produced by `view.py` only had the index in the title. For clarity, the title now shows the title and the date pair (20XXXXXX_20XXXXXX).

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
