### PR TITLE
Ignore reference point for non-referenced ifgs

### DIFF
--- a/src/mintpy/diff.py
+++ b/src/mintpy/diff.py
@@ -275,12 +275,13 @@ def diff_ifgram_stack(file1, file2, out_file):
 
     # consider reference pixel
     if 'unwrapphase' in ds_name.lower():
-        print(f'referencing to pixel ({obj1.refY},{obj1.refX}) ...')
-        ref1 = data1[:, obj1.refY, obj1.refX]
-        ref2 = data2[:, obj2.refY, obj2.refX]
-        for i in range(data1.shape[0]):
-            data1[i,:][data1[i, :] != 0.] -= ref1[i]
-            data2[i,:][data2[i, :] != 0.] -= ref2[i]
+        if all((obj1.refY is not None, obj1.refX is not None)):
+            print(f'referencing to pixel ({obj1.refY},{obj1.refX}) ...')
+            ref1 = data1[:, obj1.refY, obj1.refX]
+            ref2 = data2[:, obj2.refY, obj2.refX]
+            for i in range(data1.shape[0]):
+                data1[i,:][data1[i, :] != 0.] -= ref1[i]
+                data2[i,:][data2[i, :] != 0.] -= ref2[i]
 
     # operation and ignore zero values
     data1[data1 == 0] = np.nan


### PR DESCRIPTION
**Description of proposed changes**

An error was thrown when using `diff.py` on ifgramStack files, because diff.py expected a reference point when none was provided. It now checks whether a reference point has been set.

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Pre-commit check (green)
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
