### PR TITLE
Support EPSG-based projected CRS handling for NISAR products

### DIFF
--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -127,12 +127,17 @@ class coordinate:
 
         lat_in, lon_in = self._clean_coord(lat_in, lon_in)
 
-        # attempts to convert lat/lon to utm coordinates if needed.
+        # convert lat/lon to projected coordinates if needed.
         if (lat_in is not None and lon_in is not None
-                and 'UTM_ZONE' in self.src_metadata
+                and not self.src_metadata.get('Y_UNIT', 'degrees').lower().startswith('deg')
+                and ut0.get_epsg_code(self.src_metadata) is not None
                 and np.max(np.abs(lat_in)) <= 90
                 and np.max(np.abs(lon_in)) <= 360):
-            lat_in, lon_in = ut0.latlon2utm(self.src_metadata, np.array(lat_in), np.array(lon_in))
+            lat_in, lon_in = ut0.latlon2projected(
+                self.src_metadata,
+                np.array(lat_in),
+                np.array(lon_in),
+            )
 
         # convert coordinates
         y_out = []
@@ -297,11 +302,16 @@ class coordinate:
                 else:
                     lon[lon > 180.] -= 360
 
-        # check 2: attempts to convert lat/lon to utm coordinates if needed
-        if ('UTM_ZONE' in self.src_metadata
+        # check 2: convert lat/lon to projected coordinates if needed
+        if (not self.src_metadata.get('Y_UNIT', 'degrees').lower().startswith('deg')
+                and ut0.get_epsg_code(self.src_metadata) is not None
                 and np.max(np.abs(lat)) <= 90
                 and np.max(np.abs(lon)) <= 360):
-            lat, lon = ut0.latlon2utm(self.src_metadata, np.array(lat), np.array(lon))
+            lat, lon = ut0.latlon2projected(
+                self.src_metadata,
+                np.array(lat),
+                np.array(lon),
+            )
 
         self.open()
         if self.geocoded:

--- a/src/mintpy/objects/coord.py
+++ b/src/mintpy/objects/coord.py
@@ -128,7 +128,8 @@ class coordinate:
         lat_in, lon_in = self._clean_coord(lat_in, lon_in)
 
         # convert lat/lon to projected coordinates if needed.
-        if (lat_in is not None and lon_in is not None
+        if (all(i is not None for i in lat_in)
+                and all(i is not None for i in lon_in)
                 and not self.src_metadata.get('Y_UNIT', 'degrees').lower().startswith('deg')
                 and ut0.get_epsg_code(self.src_metadata) is not None
                 and np.max(np.abs(lat_in)) <= 90

--- a/src/mintpy/prep_nisar.py
+++ b/src/mintpy/prep_nisar.py
@@ -902,10 +902,9 @@ def get_raster_corners(input_file, polarization="HH", frequency="frequencyA"):
     with h5py.File(input_file, "r") as ds:
         xcoord = ds[datasets["xcoord"]][:]
         ycoord = ds[datasets["ycoord"]][:]
-        west = max(np.min(ds[PROCESSINFO["rdr_xcoord"]][:]), np.min(xcoord))
-        east = min(np.max(ds[PROCESSINFO["rdr_xcoord"]][:]), np.max(xcoord))
-        north = min(np.max(ds[PROCESSINFO["rdr_ycoord"]][:]), np.max(ycoord))
-        south = max(np.min(ds[PROCESSINFO["rdr_ycoord"]][:]), np.min(ycoord))
+
+    bounds, _, _ = _grid_bounds_from_xy(xcoord, ycoord)
+    west, south, east, north = bounds
     return float(west), float(south), float(east), float(north)
 
 

--- a/src/mintpy/prep_nisar.py
+++ b/src/mintpy/prep_nisar.py
@@ -18,7 +18,7 @@ from pyproj import Transformer
 from scipy.interpolate import RegularGridInterpolator
 
 from mintpy.constants import EARTH_RADIUS, SPEED_OF_LIGHT
-from mintpy.utils import attribute as attr, ptime, writefile
+from mintpy.utils import attribute as attr, ptime, utils0 as ut, writefile
 
 # ---------------------------------------------------------------------
 # Constants / HDF5 paths
@@ -801,14 +801,7 @@ def extract_metadata(input_files, bbox=None, polarization="HH", frequency="frequ
     meta["X_STEP"] = float(pixel_width)
     meta["Y_STEP"] = float(pixel_height)
 
-    if meta["EPSG"] == 4326:
-        meta["X_UNIT"] = meta["Y_UNIT"] = "degree"
-    else:
-        meta["X_UNIT"] = meta["Y_UNIT"] = "meters"
-        if str(meta["EPSG"]).startswith("326"):
-            meta["UTM_ZONE"] = str(meta["EPSG"])[3:] + "N"
-        else:
-            meta["UTM_ZONE"] = str(meta["EPSG"])[3:] + "S"
+    _set_projection_metadata(meta)
     meta["EARTH_RADIUS"] = EARTH_RADIUS
 
     # NISAR altitude
@@ -839,6 +832,16 @@ def extract_metadata(input_files, bbox=None, polarization="HH", frequency="frequ
     meta = _coerce_subset_metadata_types(meta)
 
     return meta, bounds
+
+
+def _set_projection_metadata(meta):
+    """Populate coordinate-unit metadata and optional UTM zone from EPSG."""
+    if int(meta["EPSG"]) == 4326:
+        meta["X_UNIT"] = meta["Y_UNIT"] = "degree"
+    else:
+        meta["X_UNIT"] = meta["Y_UNIT"] = "meters"
+        if str(meta["EPSG"]).startswith(("326", "327")):
+            meta["UTM_ZONE"] = ut.epsg_code2utm_zone(meta["EPSG"])
 
 
 def get_rows_cols(xcoord, ycoord, bounds):

--- a/src/mintpy/reference_point.py
+++ b/src/mintpy/reference_point.py
@@ -326,7 +326,10 @@ def read_reference_input(inps):
         print('reading reference info from reference: '+inps.reference_file)
         inps = read_reference_file2inps(inps.reference_file, inps)
 
-    if inps.ref_lat and np.abs(inps.ref_lat) > 90 and 'UTM_ZONE' not in atr.keys():
+    coord_unit = atr.get('Y_UNIT', 'degrees').lower()
+    if (inps.ref_lat is not None
+            and np.abs(inps.ref_lat) > 90
+            and coord_unit.startswith('deg')):
         msg = f'input reference latitude ({inps.ref_lat}) > 90 deg in magnitude!'
         msg += ' This does not make sense, double check your inputs!'
         raise ValueError(msg)

--- a/src/mintpy/save_hdfeos5.py
+++ b/src/mintpy/save_hdfeos5.py
@@ -127,9 +127,9 @@ def metadata_mintpy2unavco(meta_in, dateList, geom_file):
             float(meta['LAT_REF2']),
             float(meta['LAT_REF1'])]
 
-    # convert UTM to lat/lon
+    # convert projected coordinates to lat/lon
     if not meta_in.get('Y_UNIT', 'degrees').lower().startswith('deg'):
-        lats, lons = ut.utm2latlon(meta_in, easting=lons, northing=lats)
+        lats, lons = ut.projected2latlon(meta_in, easting=lons, northing=lats)
 
     unavco_meta['scene_footprint'] = "POLYGON((" + ",".join(
         [f'{lon} {lat}' for lon, lat in zip(lons, lats)]) + "))"
@@ -243,9 +243,13 @@ def get_output_filename(metadata, suffix=None, update_mode=False, subset_mode=Fa
         lat0 = lat1 + float(metadata['Y_STEP']) * int(metadata['LENGTH'])
         lon1 = lon0 + float(metadata['X_STEP']) * int(metadata['WIDTH'])
 
-        # convert UTM to lat/lon
+        # convert projected coordinates to lat/lon
         if not metadata.get('Y_UNIT', 'degrees').lower().startswith('deg'):
-            [lat0, lat1], [lon0, lon1] = ut.utm2latlon(metadata, easting=[lon0, lon1], northing=[lat0, lat1])
+            [lat0, lat1], [lon0, lon1] = ut.projected2latlon(
+                metadata,
+                easting=[lon0, lon1],
+                northing=[lat0, lat1],
+            )
 
         lat0Str = f'N{round(lat0*1e3):05d}'
         lat1Str = f'N{round(lat1*1e3):05d}'

--- a/src/mintpy/save_kmz.py
+++ b/src/mintpy/save_kmz.py
@@ -233,10 +233,10 @@ def write_kmz_overlay(data, meta, out_file, inps):
     """
 
     south, north, west, east = ut.four_corners(meta)
-    # convert from UTM to WGS84 when necessary, as KML only natively supports WGS84
-    if "UTM_ZONE" in meta.keys():
-        north, east = ut.utm2latlon(meta, east, north)
-        south, west = ut.utm2latlon(meta, west, south)
+    # convert projected coordinates to WGS84, as KML only natively supports WGS84
+    if not meta.get('Y_UNIT', 'degrees').lower().startswith('deg'):
+        north, east = ut.projected2latlon(meta, east, north)
+        south, west = ut.projected2latlon(meta, west, south)
 
     # 1. Make PNG file - Data
     print('plotting data ...')

--- a/src/mintpy/tropo_pyaps3.py
+++ b/src/mintpy/tropo_pyaps3.py
@@ -338,10 +338,10 @@ def get_bounding_box(meta, geom_file=None):
         lat1 = lat0 + lat_step * (length - 1)
         lon1 = lon0 + lon_step * (width - 1)
 
-        # for UTM projection, e.g. ASF HyP3
+        # for projected geo grids, e.g. UTM / Polar Stereographic
         if not meta.get('Y_UNIT', 'degrees').lower().startswith('deg'):
-            lat0, lon0 = ut.utm2latlon(meta, easting=lon0, northing=lat0)
-            lat1, lon1 = ut.utm2latlon(meta, easting=lon1, northing=lat1)
+            lat0, lon0 = ut.projected2latlon(meta, easting=lon0, northing=lat0)
+            lat1, lon1 = ut.projected2latlon(meta, easting=lon1, northing=lat1)
 
     else:
         # radar coordinates
@@ -364,9 +364,9 @@ def get_bounding_box(meta, geom_file=None):
             # use the rough (not accurate) lat/lon info of the four corners
             lats = [float(meta[f'LAT_REF{i}']) for i in [1,2,3,4]]
             lons = [float(meta[f'LON_REF{i}']) for i in [1,2,3,4]]
-            # for UTM projection, e.g. ASF HyP3
+            # for projected geo grids, e.g. UTM / Polar Stereographic
             if not meta.get('Y_UNIT', 'degrees').lower().startswith('deg'):
-                lats, lons = ut.utm2latlon(meta, easting=lons, northing=lats)
+                lats, lons = ut.projected2latlon(meta, easting=lons, northing=lats)
             lat0 = np.mean(lats[0:2])
             lat1 = np.mean(lats[2:4])
             lon0 = np.mean(lons[0:3:2])

--- a/src/mintpy/utils/plot.py
+++ b/src/mintpy/utils/plot.py
@@ -1148,10 +1148,10 @@ def plot_gnss(ax, SNWE, inps, metadata=dict(), print_msg=True):
     start_date = inps.gnss_start_date if inps.gnss_start_date else metadata.get('START_DATE', None)
     end_date = inps.gnss_end_date if inps.gnss_end_date else metadata.get('END_DATE', None)
 
-    # pre-query: convert UTM to lat/lon for query
-    if 'UTM_ZONE' in metadata.keys():
-        south, west = ut0.utm2latlon(atr, SNWE[2], SNWE[0])
-        north, east = ut0.utm2latlon(atr, SNWE[3], SNWE[1])
+    # pre-query: convert projected x/y to lat/lon for query
+    if not metadata.get('Y_UNIT', 'degrees').lower().startswith('deg'):
+        south, west = ut0.projected2latlon(atr, SNWE[2], SNWE[0])
+        north, east = ut0.projected2latlon(atr, SNWE[3], SNWE[1])
         SNWE = (south, north, west, east)
 
     # query for GNSS stations
@@ -1186,9 +1186,9 @@ def plot_gnss(ax, SNWE, inps, metadata=dict(), print_msg=True):
     vprint(f'GNSS source: {gnss_obj.source}')
     vprint(f'GNSS reference frame: {gnss_obj.version}')
 
-    # post-query: convert lat/lon to UTM for plotting
-    if 'UTM_ZONE' in metadata.keys():
-        site_lats, site_lons = ut0.latlon2utm(metadata, site_lats, site_lons)
+    # post-query: convert lat/lon to projected x/y for plotting
+    if not metadata.get('Y_UNIT', 'degrees').lower().startswith('deg'):
+        site_lats, site_lons = ut0.latlon2projected(metadata, site_lats, site_lons)
 
     # mask out stations not coincident with InSAR data
     if inps.mask_gnss and inps.msk is not None:

--- a/src/mintpy/utils/utils.py
+++ b/src/mintpy/utils/utils.py
@@ -490,9 +490,9 @@ def prepare_geo_los_geometry(geom_file, unit='rad'):
         S = N + y_step * length
         E = W + x_step * width
 
-        # SNWE in meter --> degree
-        lat0, lon0 = utm2latlon(atr, W, N)
-        lat1, lon1 = utm2latlon(atr, E, S)
+        # projected x/y --> degree
+        lat0, lon0 = projected2latlon(atr, W, N)
+        lat1, lon1 = projected2latlon(atr, E, S)
         lat_step = (lat1 - lat0) / length
         lon_step = (lon1 - lon0) / width
 

--- a/src/mintpy/utils/utils0.py
+++ b/src/mintpy/utils/utils0.py
@@ -334,6 +334,51 @@ def epsg_code2utm_zone(epsg_code):
     return utm_zone
 
 
+def _metadata_value_exists(meta, key):
+    """Return True if the metadata key exists and carries a usable value."""
+    value = meta.get(key, None)
+    return value not in [None, '', 'None', 'none']
+
+
+def _format_transform_output(ref1, ref2, out1, out2):
+    """Match transform output type to the input coordinate type."""
+    if any(isinstance(x, (list, tuple)) for x in [ref1, ref2]):
+        return out1.tolist(), out2.tolist()
+
+    if np.isscalar(ref1) and np.isscalar(ref2):
+        return np.asarray(out1).item(), np.asarray(out2).item()
+
+    return out1, out2
+
+
+def get_utm_zone(meta):
+    """Return the UTM zone for metadata, or None for a non-UTM CRS."""
+    if _metadata_value_exists(meta, 'EPSG'):
+        return epsg_code2utm_zone(int(meta['EPSG']))
+
+    if _metadata_value_exists(meta, 'UTM_ZONE'):
+        return meta['UTM_ZONE']
+
+    return None
+
+
+def get_epsg_code(meta):
+    """Return the EPSG code for metadata, or None if unavailable."""
+    if _metadata_value_exists(meta, 'EPSG'):
+        return int(meta['EPSG'])
+
+    utm_zone = get_utm_zone(meta)
+    if utm_zone:
+        return int(utm_zone2epsg_code(utm_zone))
+
+    return None
+
+
+def is_utm_crs(meta):
+    """Return True if the metadata represents a true UTM CRS."""
+    return get_utm_zone(meta) is not None
+
+
 def to_latlon(infile, x, y):
     """Convert x, y in the projection coordinates of the file to lat/lon in degree.
 
@@ -375,8 +420,12 @@ def utm2latlon(meta, easting, northing):
                 lon      - scalar/list/tuple/1-2D np.ndarray, WGS 84 coordinates in x direction
     """
     import utm
-    zone_num = int(meta['UTM_ZONE'][:-1])
-    northern = meta['UTM_ZONE'][-1].upper() == 'N'
+    utm_zone = get_utm_zone(meta)
+    if utm_zone is None:
+        raise ValueError('Input metadata is NOT in a UTM CRS.')
+
+    zone_num = int(utm_zone[:-1])
+    northern = utm_zone[-1].upper() == 'N'
     # set 'strict=False' to allow coordinates outside the range of a typical single UTM zone,
     # which can be common for large area analysis, e.g. the Norwegian mapping authority
     # publishes a height data in UTM zone 33 coordinates for the whole country, even though
@@ -384,12 +433,7 @@ def utm2latlon(meta, easting, northing):
     lat, lon = utm.to_latlon(np.array(easting), np.array(northing), zone_num,
                              northern=northern, strict=False)
 
-    # output format
-    if any(isinstance(x, (list, tuple)) for x in [easting, northing]):
-        lat = lat.tolist()
-        lon = lon.tolist()
-
-    return lat, lon
+    return _format_transform_output(easting, northing, lat, lon)
 
 
 def latlon2utm(meta, lat, lon):
@@ -406,15 +450,48 @@ def latlon2utm(meta, lat, lon):
 
     # invoke zone_num to ensure all coordinates are converted into the same single UTM zone,
     # even if they cross a UTM boundary.
-    zone_num = int(meta['UTM_ZONE'][:-1])
+    utm_zone = get_utm_zone(meta)
+    if utm_zone is None:
+        raise ValueError('Input metadata is NOT in a UTM CRS.')
+
+    zone_num = int(utm_zone[:-1])
     easting, northing = utm.from_latlon(np.array(lat), np.array(lon), force_zone_number=zone_num)[:2]
 
-    # output format
-    if any(isinstance(x, (list, tuple)) for x in [lat, lon]):
-        easting = easting.tolist()
-        northing = northing.tolist()
+    return _format_transform_output(lat, lon, northing, easting)
 
-    return northing, easting
+
+def projected2latlon(meta, easting, northing):
+    """Convert projected x/y coordinates into lat/lon using metadata EPSG."""
+    from pyproj import CRS, Transformer
+
+    epsg_code = get_epsg_code(meta)
+    if epsg_code is None:
+        raise ValueError('No EPSG or UTM metadata found for projected-to-lat/lon conversion.')
+
+    transformer = Transformer.from_crs(
+        CRS.from_epsg(epsg_code),
+        CRS.from_epsg(4326),
+        always_xy=True,
+    )
+    lon, lat = transformer.transform(np.array(easting), np.array(northing))
+    return _format_transform_output(easting, northing, lat, lon)
+
+
+def latlon2projected(meta, lat, lon):
+    """Convert lat/lon into projected x/y coordinates using metadata EPSG."""
+    from pyproj import CRS, Transformer
+
+    epsg_code = get_epsg_code(meta)
+    if epsg_code is None:
+        raise ValueError('No EPSG or UTM metadata found for lat/lon-to-projected conversion.')
+
+    transformer = Transformer.from_crs(
+        CRS.from_epsg(4326),
+        CRS.from_epsg(epsg_code),
+        always_xy=True,
+    )
+    easting, northing = transformer.transform(np.array(lon), np.array(lat))
+    return _format_transform_output(lat, lon, northing, easting)
 
 
 def snwe_to_wkt_polygon(snwe):
@@ -484,10 +561,14 @@ def get_lat_lon(meta, geom_file=None, box=None, dimension=2, ystep=1, xstep=1):
         else:
             raise ValueError(f'un-supported dimension = {dimension}')
 
-        # UTM to lat/lon
-        if not meta['Y_UNIT'].startswith('deg') and 'UTM_ZONE' in meta.keys():
-            print('UTM coordinates detected, convert UTM into lat/lon')
-            lats, lons = utm2latlon(meta, easting=lons, northing=lats)
+        # projected x/y to lat/lon
+        if not meta.get('Y_UNIT', 'degrees').lower().startswith('deg'):
+            if is_utm_crs(meta):
+                print('UTM coordinates detected, convert UTM into lat/lon')
+                lats, lons = utm2latlon(meta, easting=lons, northing=lats)
+            elif get_epsg_code(meta) is not None:
+                print('Projected coordinates detected, convert projected x/y into lat/lon')
+                lats, lons = projected2latlon(meta, easting=lons, northing=lats)
 
     else:
         msg = 'Can not get pixel-wise lat/lon!'

--- a/src/mintpy/view.py
+++ b/src/mintpy/view.py
@@ -218,6 +218,15 @@ def check_map_projection(inps, metadata, print_msg=True):
                 if inps.lalo_label:
                     raise ValueError('--lalo-label is NOT supported for projection: UTM')
 
+            elif metadata.get('EPSG', None):
+                try:
+                    inps.map_proj_obj = ccrs.epsg(int(metadata['EPSG']))
+                    print(msg + f'EPSG {metadata["EPSG"]}')
+                except Exception:
+                    print(f'WARNING: Failed to initialize cartopy projection for EPSG {metadata["EPSG"]}')
+                    print('    Switch to the native Y/X and continue to plot')
+                    inps.fig_coord = 'yx'
+
             else:
                 print(f'WARNING: Un-recognized coordinate unit: {inps.coord_unit}')
                 print('    Switch to the native Y/X and continue to plot')


### PR DESCRIPTION
## Summary
- Add EPSG-backed projected coordinate transforms alongside existing UTM helpers
- Use projected CRS metadata consistently for NISAR preparation, reference-point validation, plotting, KMZ/HDF-EOS export, and tropospheric bounding boxes
- Preserve UTM zone metadata only for true UTM EPSG codes while allowing non-UTM projected grids such as **polar stereographic**
- Use geocoded raster bounds directly for NISAR overlap calculations
